### PR TITLE
Fixed adding units again when onResume is called after minimize app

### DIFF
--- a/CarLogbook/src/main/java/com/enadein/carlogbook/core/UnitFacade.java
+++ b/CarLogbook/src/main/java/com/enadein/carlogbook/core/UnitFacade.java
@@ -248,8 +248,12 @@ public class UnitFacade {
                 return ctx.getString(R.string.na);
             }
         }
-
-        return wrap ? currentText + " (" + value + ")" : currentText + value;
+		
+		if ((wrap && currentText.endsWith("(" + value + ")")) || (!wrap && currentText.endsWith(value))) {
+			return currentText;
+		} else {
+			return wrap ? currentText + " (" + value + ")" : currentText + value;
+		}
     }
 
     public void setFuelValue(int fuelValue) {


### PR DESCRIPTION
Steps to reproduce bug:

1. Open app, go to Report screen. Go to cost per {unit} sections.
2. Press Home button to return to Desktop.
3. Return to the minimized app and go back to cost per {unit} sections. Now titles have the unit added again (for example: Cost/1kmkm or Fuel cost/1kmkm)

Repeat steps and it will be added again.