### PR TITLE
Fix: squid:S1319, Use Java collection interfaces rather than specific…

### DIFF
--- a/CarLogbook/src/main/java/com/enadein/carlogbook/bean/Dashboard.java
+++ b/CarLogbook/src/main/java/com/enadein/carlogbook/bean/Dashboard.java
@@ -17,7 +17,7 @@
 */
 package com.enadein.carlogbook.bean;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class Dashboard {
 	private double totalOdometerCount; //mileage/run
@@ -69,44 +69,44 @@ public class Dashboard {
 	private double odometerCountByMonthAvg;
 	private double odometerCountByDayAvg;
 
-	private ArrayList<BarInfo> costLast4Months;
-	private ArrayList<BarInfo> incomeLast4Months;
-	private ArrayList<BarInfo> fuelCostPer1;
-	private ArrayList<BarInfo> costPer1;
+	private List<BarInfo> costLast4Months;
+	private List<BarInfo> incomeLast4Months;
+	private List<BarInfo> fuelCostPer1;
+	private List<BarInfo> costPer1;
 
-	public ArrayList<BarInfo> getFuelCostPer1() {
+	public List<BarInfo> getFuelCostPer1() {
 		return fuelCostPer1;
 	}
 
-	public void setFuelCostPer1(ArrayList<BarInfo> fuelCostPer1) {
+	public void setFuelCostPer1(List<BarInfo> fuelCostPer1) {
 		this.fuelCostPer1 = fuelCostPer1;
 	}
 
-	public ArrayList<BarInfo> getCostPer1() {
+	public List<BarInfo> getCostPer1() {
 		return costPer1;
 	}
 
-	public void setCostPer1(ArrayList<BarInfo> costPer1) {
+	public void setCostPer1(List<BarInfo> costPer1) {
 		this.costPer1 = costPer1;
 	}
 
-	public ArrayList<BarInfo> getIncomeLast4Months() {
+	public List<BarInfo> getIncomeLast4Months() {
 		return incomeLast4Months;
 	}
 
-	public void setIncomeLast4Months(ArrayList<BarInfo> incomeLast4Months) {
+	public void setIncomeLast4Months(List<BarInfo> incomeLast4Months) {
 		this.incomeLast4Months = incomeLast4Months;
 	}
 
-	public ArrayList<BarInfo> getRunLast4Months() {
+	public List<BarInfo> getRunLast4Months() {
 		return runLast4Months;
 	}
 
-	public void setRunLast4Months(ArrayList<BarInfo> runLast4Months) {
+	public void setRunLast4Months(List<BarInfo> runLast4Months) {
 		this.runLast4Months = runLast4Months;
 	}
 
-	private ArrayList<BarInfo> runLast4Months;
+	private List<BarInfo> runLast4Months;
 
 
 	public double getTotalOdometerCount() {
@@ -213,11 +213,11 @@ public class Dashboard {
 		this.totalPartsPrice = totalPartsPrice;
 	}
 
-	public ArrayList<BarInfo> getCostLast4Months() {
+	public List<BarInfo> getCostLast4Months() {
 		return costLast4Months;
 	}
 
-	public void setCostLast4Months(ArrayList<BarInfo> costLast4Months) {
+	public void setCostLast4Months(List<BarInfo> costLast4Months) {
 		this.costLast4Months = costLast4Months;
 	}
 }

--- a/CarLogbook/src/main/java/com/enadein/carlogbook/bean/DataInfo.java
+++ b/CarLogbook/src/main/java/com/enadein/carlogbook/bean/DataInfo.java
@@ -23,7 +23,7 @@ import android.content.Context;
 import com.enadein.carlogbook.R;
 import com.enadein.carlogbook.core.CarsDataInfo;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -91,7 +91,7 @@ public class DataInfo {
 	}
 
 	private Dashboard dashboard = new Dashboard();
-	private ArrayList<ReportItem> reportData;
+	private List<ReportItem> reportData;
 
     private XReport xReport;
 
@@ -107,11 +107,11 @@ public class DataInfo {
 		return dashboard;
 	}
 
-	public ArrayList<ReportItem> getReportData() {
+	public List<ReportItem> getReportData() {
 		return reportData;
 	}
 
-	public void setReportData(ArrayList<ReportItem> reportData) {
+	public void setReportData(List<ReportItem> reportData) {
 		this.reportData = reportData;
 	}
 }

--- a/CarLogbook/src/main/java/com/enadein/carlogbook/core/ReportExportLoader.java
+++ b/CarLogbook/src/main/java/com/enadein/carlogbook/core/ReportExportLoader.java
@@ -23,6 +23,7 @@ import com.enadein.carlogbook.ui.CreateReportActivity;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 public class ReportExportLoader extends AsyncTaskLoader<File> {
 	private final UnitFacade unitFacade;
@@ -122,7 +123,7 @@ public class ReportExportLoader extends AsyncTaskLoader<File> {
 			DataLoader dl = new DataLoader(getContext(),
 					DataLoader.TYPE, null, unitFacade);
 			DataInfo di = dl.loadInBackground();
-			ArrayList<ReportItem> items = di.getReportData();
+			List<ReportItem> items = di.getReportData();
 
 			for (ReportItem item: items) {
 				printLine(item.getName(),

--- a/CarLogbook/src/main/java/com/enadein/carlogbook/ui/LastUpdatedReportFragment.java
+++ b/CarLogbook/src/main/java/com/enadein/carlogbook/ui/LastUpdatedReportFragment.java
@@ -36,7 +36,7 @@ import com.enadein.carlogbook.core.BaseReportFragment;
 import com.enadein.carlogbook.core.CarChangedListener;
 import com.enadein.carlogbook.core.DataLoader;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class LastUpdatedReportFragment extends BaseReportFragment implements LoaderManager.LoaderCallbacks<DataInfo>,CarChangedListener {
 	private ListView listView;
@@ -76,7 +76,7 @@ public class LastUpdatedReportFragment extends BaseReportFragment implements Loa
 
 	@Override
 	public void onLoadFinished(Loader<DataInfo> loader, DataInfo data) {
-		ArrayList<ReportItem> items = data.getReportData();
+		List<ReportItem> items = data.getReportData();
 		SimpleReportAdapter adapter = new SimpleReportAdapter(getActivity(),
 				R.layout.report_item_simple, items.toArray(new ReportItem[] {}), getMediator().getUnitFacade());
 		listView.setAdapter(adapter);

--- a/CarLogbook/src/main/java/com/enadein/carlogbook/ui/TypeReportFragment.java
+++ b/CarLogbook/src/main/java/com/enadein/carlogbook/ui/TypeReportFragment.java
@@ -40,9 +40,9 @@ import com.enadein.carlogbook.core.CarChangedListener;
 import com.enadein.carlogbook.core.DataLoader;
 import com.enadein.carlogbook.db.CommonUtils;
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 public class TypeReportFragment extends BaseReportFragment implements LoaderManager.LoaderCallbacks<DataInfo>,CarChangedListener {
 	public static final String DATE_PICKER = "date_picker";
@@ -141,7 +141,7 @@ public class TypeReportFragment extends BaseReportFragment implements LoaderMana
 
 	@Override
 	public void onLoadFinished(Loader<DataInfo> loader, DataInfo data) {
-		ArrayList<ReportItem> items = data.getReportData();
+		List<ReportItem> items = data.getReportData();
 		SimpleReportAdapter adapter = new SimpleReportAdapter(getActivity(),
 				R.layout.report_item_simple, items.toArray(new ReportItem[] {}), getMediator().getUnitFacade(), getResources().getColor(R.color.price));
 		listView.setAdapter(adapter);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1319

 Please let me know if you have any questions.
Ayman Elkfrawy.