### PR TITLE
Fix: squid:S1192, String literals should not be duplicated

### DIFF
--- a/CarLogbook/src/main/java/com/enadein/carlogbook/core/ReportExportLoader.java
+++ b/CarLogbook/src/main/java/com/enadein/carlogbook/core/ReportExportLoader.java
@@ -25,6 +25,9 @@ import java.util.ArrayList;
 import java.util.Date;
 
 public class ReportExportLoader extends AsyncTaskLoader<File> {
+	public static final String BLACK = "black";
+	public static final String RED = "red";
+	public static final String BLUE = "blue";
 	private final UnitFacade unitFacade;
 	private boolean loaded = false;
 	private Bundle bundle;
@@ -66,47 +69,47 @@ public class ReportExportLoader extends AsyncTaskLoader<File> {
 
 			printLine(
 					res.getString(R.string.total_cost),
-					"black",
+					BLACK,
 					unitFacade.appendCurrency(false, CommonUtils.formatPriceNew(b.getTotalPrice(), unitFacade)),
-					"red");
+					RED);
 			printLine(
 					res.getString(R.string.total_run),
-					"black",
+					BLACK,
 					unitFacade.appendDistUnit(false, CommonUtils.formatDistance(b.getTotalOdometerCount())),
-					"black");
+					BLACK);
 
 			printLine(
 					res.getString(R.string.total_fuel),
-					"black",
+					BLACK,
 					unitFacade.appendFuelUnit(false, CommonUtils.formatFuel(b.getTotalFuelCount(), unitFacade)),
-					"blue");
+					BLUE);
 
 			printLine(
 					unitFacade.appendDistUnit(false, res.getString(R.string.cost_per1)),
-					"black",
+					BLACK,
 					unitFacade.appendCurrency(false, CommonUtils.formatPriceNew(b.getPricePer1(), unitFacade)),
-					"black");
+					BLACK);
 			printLine(
 					unitFacade.appendDistUnit(false, res.getString(R.string.cost1fuelper1)),
-					"black",
+					BLACK,
 					unitFacade.appendCurrency(false, CommonUtils.formatPriceNew(b.getPriceFuelPer1(), unitFacade)),
-					"red");
+					RED);
 ///---
 			printLine(
 					unitFacade.appendConsumUnit(true, res.getString(R.string.avg_fuel), 0),
-					"black",
+					BLACK,
 					unitFacade.appendFuelUnit(false, CommonUtils.formatFuel(b.getFuelRateAvg100(), unitFacade)),
-					"blue");
+					BLUE);
 			printLine(
 					unitFacade.appendConsumUnit(true, res.getString(R.string.avg_fuel), 2),
-					"black",
+					BLACK,
 					unitFacade.appendDistUnit(false, CommonUtils.formatDistance(b.getFuelRateAvg())),
-					"black");
+					BLACK);
 			printLine(
 					unitFacade.appendConsumUnit(true, res.getString(R.string.avg_fuel), 1),
-					"black",
+					BLACK,
 					unitFacade.appendFuelUnit(false, CommonUtils.formatFuel(b.getFuelRateAvg2(), unitFacade)),
-					"blue");
+					BLUE);
 
 
 
@@ -126,9 +129,9 @@ public class ReportExportLoader extends AsyncTaskLoader<File> {
 
 			for (ReportItem item: items) {
 				printLine(item.getName(),
-						"black",
+						BLACK,
 						unitFacade.appendCurrency(false, CommonUtils.formatPriceNew(item.getValue(), unitFacade)),
-						"red");
+						RED);
 			}
 
 			writer.endTable();
@@ -186,18 +189,18 @@ public class ReportExportLoader extends AsyncTaskLoader<File> {
 			int fuelNameIdx = cursor.getColumnIndex(ProviderDescriptor.LogView.Cols.FUEL_NAME);
 			String fuelName = cursor.getString(fuelNameIdx);
 
-			printCell(date, "black");
+			printCell(date, BLACK);
 			String odometerValue = unitFacade.appendDistUnit(false, String.valueOf(odometer));
-			printCell(odometerValue, "black");
+			printCell(odometerValue, BLACK);
 			String fuelValueString = unitFacade.appendFuelUnit(false, CommonUtils.formatFuel(fuelValue, unitFacade));
-			printCell(fuelValueString, "black");
+			printCell(fuelValueString, BLACK);
 
 			String stationAndFuel = fuelName + "(" + stationName + ")";
-			printCell(stationAndFuel, "black");
-			printCell(getFuelRate(id), "black");
+			printCell(stationAndFuel, BLACK);
+			printCell(getFuelRate(id), BLACK);
 
 			String priceStringValue = unitFacade.appendCurrency(false, CommonUtils.formatPriceNew(priceTotalDouble, unitFacade));
-			printCell(priceStringValue, "red");
+			printCell(priceStringValue, RED);
 
 
 
@@ -210,11 +213,11 @@ public class ReportExportLoader extends AsyncTaskLoader<File> {
 			String name = cursor.getString(nameIdx);
 			int typeId = cursor.getInt(typeIdx);
 
-			printCell(date, "black");
+			printCell(date, BLACK);
 			String odometerValue = unitFacade.appendDistUnit(false, String.valueOf(odometer));
-			printCell(odometerValue, "black");
+			printCell(odometerValue, BLACK);
 
-			printCell(name, "black");
+			printCell(name, BLACK);
 
 			String nameString  = "";
 			if (typeId == 0) {
@@ -229,10 +232,10 @@ public class ReportExportLoader extends AsyncTaskLoader<File> {
 				nameString = types[typeId];
 			}
 
-			printCell(nameString, "black");
-			printCell( "&nbsp", "black");
+			printCell(nameString, BLACK);
+			printCell( "&nbsp", BLACK);
 			String priceStringValue = unitFacade.appendCurrency(false, CommonUtils.formatPriceNew(price, unitFacade));
-			printCell(priceStringValue, (typeId == 12) ? "green" : "red");
+			printCell(priceStringValue, (typeId == 12) ? "green" : RED);
 		}
 	}
 

--- a/CarLogbook/src/main/java/com/enadein/carlogbook/db/CarLogbookProvider.java
+++ b/CarLogbook/src/main/java/com/enadein/carlogbook/db/CarLogbookProvider.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 
 public class CarLogbookProvider extends ContentProvider {
 	public static final String LIMIT_PARAM = "limit_param";
+	public static final String UNKNOWN_URI = "Unknown URI ";
 	protected DBOpenHelper dbHelper;
 
 	protected HashMap<Integer, String> tables = new HashMap<Integer, String>();
@@ -98,7 +99,7 @@ public class CarLogbookProvider extends ContentProvider {
 		}
 
 		if (tableName == null) {
-			throw new IllegalArgumentException("Unknown URI " + uri);
+			throw new IllegalArgumentException(UNKNOWN_URI + uri);
 		}
 
 		SQLiteQueryBuilder builder = new SQLiteQueryBuilder();
@@ -126,7 +127,7 @@ public class CarLogbookProvider extends ContentProvider {
 
 		String result = types.get(token);
 		if (result == null) {
-			throw new IllegalArgumentException("Unknown URI " + uri);
+			throw new IllegalArgumentException(UNKNOWN_URI + uri);
 		}
 
 		return result;
@@ -141,7 +142,7 @@ public class CarLogbookProvider extends ContentProvider {
 
 		String tableName = tables.get(token);
 		if (tableName == null) {
-			throw new IllegalArgumentException("Unknown URI " + uri);
+			throw new IllegalArgumentException(UNKNOWN_URI + uri);
 		}
 
 		long id = db.insert(tableName, null, values);
@@ -159,7 +160,7 @@ public class CarLogbookProvider extends ContentProvider {
 
 		String tableName = tables.get(token);
 		if (tableName == null) {
-			throw new IllegalArgumentException("Unknown URI " + uri);
+			throw new IllegalArgumentException(UNKNOWN_URI + uri);
 		}
 
 		result = db.delete(tableName, selection, selectionArgs);
@@ -176,7 +177,7 @@ public class CarLogbookProvider extends ContentProvider {
 
 		String tableName = tables.get(token);
 		if (tableName == null) {
-			throw new IllegalArgumentException("Unknown URI " + uri);
+			throw new IllegalArgumentException(UNKNOWN_URI + uri);
 		}
 
 		result = db.update(tableName, values, selection, selectionArgs);
@@ -191,7 +192,7 @@ public class CarLogbookProvider extends ContentProvider {
 
 		String tableName = tables.get(token);
 		if (tableName == null) {
-			throw new IllegalArgumentException("Unknown URI " + uri);
+			throw new IllegalArgumentException(UNKNOWN_URI + uri);
 		}
 
 		db.beginTransaction();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192

 Please let me know if you have any questions.
Ayman Elkfrawy.